### PR TITLE
Improve episodic definition

### DIFF
--- a/4_EpisodicSalinization.R
+++ b/4_EpisodicSalinization.R
@@ -17,7 +17,7 @@ p4_targets <- list(
                             date_colname = 'dateTime',
                             param_colname = 'SpecCond_norm',
                             sb_pk_thresh = 0.000005,
-                            sf_pk_thresh = 0.1) # TODO: THIS SHOULD JUST BE 0 OR -0.1!
+                            sf_pk_thresh = 0)
       ) %>% bind_rows()
   }),
   

--- a/4_EpisodicSalinization.R
+++ b/4_EpisodicSalinization.R
@@ -26,7 +26,6 @@ p4_targets <- list(
   tar_target(p4_ts_sc_peak_summary, 
              summarize_salt_peaks(p4_ts_sc_peaks, 
                                   min_perc_peaks_winter = 0.35, 
-                                  # min_perc_diff = 0.10,
                                   min_perc_winter_higher = 0.65)),
   tar_target(p4_episodic_sites, filter(p4_ts_sc_peak_summary, is_salt_site)$site_no)
   

--- a/4_EpisodicSalinization.R
+++ b/4_EpisodicSalinization.R
@@ -25,8 +25,8 @@ p4_targets <- list(
   # our criteria for exhibiting "episodic" patterns in winter.
   tar_target(p4_ts_sc_peak_summary, 
              summarize_salt_peaks(p4_ts_sc_peaks, 
-                                  min_perc_peaks_winter = 0.35, 
-                                  min_perc_winter_higher = 0.65)),
-  tar_target(p4_episodic_sites, filter(p4_ts_sc_peak_summary, is_salt_site)$site_no)
+                                  num_peaks_per_year = 3, 
+                                  spec_cond_buffer = 200)),
+  tar_target(p4_episodic_sites, filter(p4_ts_sc_peak_summary, is_episodic)$site_no)
   
 )

--- a/4_EpisodicSalinization/src/summarize_sc_peaks.R
+++ b/4_EpisodicSalinization/src/summarize_sc_peaks.R
@@ -4,108 +4,61 @@
 #' will summarize peaks per site based on whether or not they occurred during
 #' winter. Then, it will add a new field indicating whether the site qualifies
 #' as an "episodic winter salting site", meaning that specific conductance
-#' peaks occur during the winter a minimum percent of the time, the difference
-#' between winter and non-winter average specific conductance is greater than 
-#' some minimum percent, and the annual maximum specific conductance occurs during
-#' the winter a minimum percent of the time.
+#' peaks in winter are much larger than those outside of winter.
 #' 
 #' @param ts_peak_data a tibble output from `find_event_peaks()` with at least the 
 #' columns `site_no`, `dateTime`, and `peak_flag`.
 #' @param winter_months a numeric vector indicating which months should be 
 #' considered "winter"; defaults to `c(12,1,2,3)` or Dec, Jan, Feb, and Mar.
-#' @param min_perc_peaks_winter a single numeric value indicating the percentage of 
-#' time the peak values should occur in winter to qualify the site as an episodic
-#' winter salting site. Given as a fraction; defaults to `0.50` (or 50%).
-#' @param min_perc_winter_higher a single numeric value indicating the percentage
-#' of years that the maximum annual specific conductance for a particular site
-#' should occur during the winter in order to qualify as an episodic winter
-#' salting site. Given as a fraction; defaults to `0.75` (or 75%).
+#' @param num_peaks_per_year a single numeric value indicating the number of
+#' top peaks to use per year in winter and outside of winter in order to 
+#' compare winter peaks to non-winter peaks.
+#' @param spec_cond_buffer a single numeric value in `uS/cm@25degC` indicating
+#' the amount by which median winter peak specific conductance needs to be higher
+#' than median non-winter peak specific conductance. 
 #' 
 summarize_salt_peaks <- function(ts_peak_data, winter_months = c(12,1,2,3), 
-                                 min_perc_peaks_winter = 0.50,  
-                                 min_perc_winter_higher = 0.75) {
+                                 num_peaks_per_year, spec_cond_buffer) {
   
-  # Calculate maximum SpC by site, year, and season. Then determine annual 
-  # seasonal maximums to use when qualifying a site as an episodic site or
-  # not because winter maximums should be greater than non-winter maximums 
-  # a majority of the time series to qualify
-  salt_sites_max_info <- ts_peak_data %>% 
-    # Create a winter flag - if month in (12,1,2,3)
-    mutate(year = year(dateTime), 
-           is_winter = month(dateTime) %in% winter_months) %>% 
-    group_by(site_no, year, is_winter) %>% 
-    # Calculate two maximums per year - one for winter, one for not winter
-    summarize(maxSpC = max(SpecCond, na.rm=TRUE), .groups = 'keep') %>% 
-    # Pivot wider so that the winter and non-winter maximums are each their own column
-    mutate(is_winter = ifelse(is_winter, 'winterSpCMax', 'notWinterSpCMax')) %>% 
-    pivot_wider(names_from = is_winter, values_from = maxSpC) %>% 
-    # Get rid of years that don't have a value for both winter/not winter
-    filter(!is.na(winterSpCMax) & !is.na(notWinterSpCMax)) %>% 
-    # Summarize the total number of years and the number of years where the
-    # winter maximum was higher than the non-winter maximum
-    group_by(site_no) %>% 
-    summarize(n_years = n(), 
-              n_winter_higher = sum(winterSpCMax > notWinterSpCMax), 
-              .groups = 'keep') %>% 
-    # Calculate the percent that the winter maximum was higher
-    mutate(perc_winter_max_higher = n_winter_higher / n_years) %>% 
-    select(site_no, perc_winter_max_higher)
   
-  # Calculate of the 10 largest peaks each winter, how many occur in winter ('winterPeaks)
-  # Also calculate the different between the peakSpc and the mean Spc
-  salt_peaks = ts_peak_data %>% 
+  ts_peak_data %>% 
+    
+    # Identify which dates are in winter
     mutate(is_winter = month(dateTime) %in% winter_months) %>% 
+    
+    # First keep only years where there is sufficient data in winter (>60 days)
     group_by(site_no, year = year(dateTime)) %>% 
     mutate(winterSum = sum(is_winter)) %>% 
-    filter(winterSum > 60) %>% # need sufficient winter data (>60 days)
+    # This removes 488 site-years (out of 3,302 so ~15% dropped)
+    filter(winterSum > 60) %>%
+    
+    # Now filter to only peaks themselves (which removes other data that may
+    # be part of one of the peak events but isn't the peak itself)
+    filter(peak_flag) %>% 
+    
+    # Change `is_winter` to be season and show winter vs not winter
+    mutate(season = ifelse(is_winter, 'winter', 'not_winter')) %>% 
+    select(-is_winter) %>% 
+    
+    # Find top peaks per site per year per season 
+    group_by(site_no, year, season) %>% 
     arrange(desc(SpecCond)) %>% 
-    slice(1:10) %>% 
-    summarise(winterPeaks = sum(is_winter), peakSpc = mean(SpecCond, na.rm = TRUE)) %>% 
-    left_join(ts_peak_data %>% group_by(site_no, year = year(dateTime)) %>% 
-                summarise(meanSpc = mean(SpecCond, na.rm = TRUE))) %>% 
-    group_by(site_no) %>% 
-    summarise_all(mean) %>% 
-    select(-year)
-  
-  
-  salt_sites_info <- ts_peak_data %>% 
-    # Create a winter flag - if month in (12,1,2,3)
-    mutate(is_winter = month(dateTime) %in% winter_months) %>% 
-    # Tally number of peaks and calculate average SpC for winter/non-winter 
-    group_by(site_no, is_winter) %>% 
-    summarize(n_peaks = sum(peak_flag, na.rm=T),
-              avg_sc = mean(SpecCond, na.rm = T),
-              .groups = 'keep') %>% 
-    # Calculate the percent of peaks per season
-    group_by(site_no) %>% 
-    mutate(n_peaks_total = sum(n_peaks, na.rm=TRUE),
-           peaks_perc = n_peaks/n_peaks_total) %>% 
-    select(site_no, is_winter, peaks_perc, avg_sc) %>% 
-    # Munge the data so that there is a column per metric per season
-    pivot_longer(cols = -c(site_no, is_winter), names_to = 'metric') %>% 
-    mutate(metric_season = sprintf('%s_%s', metric, ifelse(is_winter, 'winterYes', 'winterNo'))) %>% 
-    pivot_wider(id_cols = site_no, names_from = metric_season, values_from = value) %>%
-    # Calculate the percent difference between winter and non-winter average SpC
-    group_by(site_no) %>% 
-    mutate(sc_perc_diff = ((avg_sc_winterYes - avg_sc_winterNo) / avg_sc_winterYes)) %>%
-    select(site_no, peaks_perc_winterYes, sc_perc_diff)
-  
-  # Now join these data for each site and determine which sites meet criteria 
-  # for being considered 'episodic'. To qualify as winter salting sites for 
-  # this analysis, 1) more than `min_perc_peaks_winter` of the SpC peaks need to happen 
-  # during winter, 2) the percent difference between winter and non-winter
-  # SpC averages should be greater than `min_perc_diff`, and 3) the maximum annual
-  # SpC value should occur in winter more than `min_perc_winter_higher` percent
-  salt_sites_info %>% 
-    # Join in the data about winter maximums
-    left_join(salt_sites_max_info, by = 'site_no') %>% 
-    left_join(salt_peaks, by = 'site_no') %>% 
-    mutate(is_salt_site = 
-             # More than `min_perc_peaks_winter` percent of global peaks must occur in winter
-             peaks_perc_winterYes > min_perc_peaks_winter & 
-             winterPeaks > 6 &
-             peakSpc >= 200 + meanSpc &
-             # Maximum annual SpC should occur in winter more than `` percent of the years
-             perc_winter_max_higher > min_perc_winter_higher)
+    slice(1:num_peaks_per_year) %>%
+    ungroup() %>% 
+    
+    # Now calculate median SpC per site per season using only those top peaks
+    group_by(site_no, season) %>% 
+    summarize(medianSpC = median(SpecCond, na.rm=TRUE), .groups='keep') %>% 
+    ungroup() %>% 
+    
+    # Pivot so that each site has a row and each season has a column 
+    # containing the median SpC of the top `num_peaks_per_year`
+    pivot_wider(id_cols = c('site_no'), 
+                names_from = 'season', 
+                values_from = medianSpC) %>% 
+    
+    # Now determine whether a site is episodic by comparing winter vs non-winter
+    # and applying a buffer so that winter is "much higher"
+    mutate(is_episodic = winter >= not_winter + spec_cond_buffer)
   
 }

--- a/4_EpisodicSalinization/src/summarize_sc_peaks.R
+++ b/4_EpisodicSalinization/src/summarize_sc_peaks.R
@@ -16,17 +16,13 @@
 #' @param min_perc_peaks_winter a single numeric value indicating the percentage of 
 #' time the peak values should occur in winter to qualify the site as an episodic
 #' winter salting site. Given as a fraction; defaults to `0.50` (or 50%).
-#' @param min_perc_diff a single numeric value indicating the minimum percent  
-#' difference between average winter and non-winter specific conductance to 
-#' qualify the site as an episodic winter salting site. Given as a fraction; 
-#' defaults to `0.10` (or 10%).
 #' @param min_perc_winter_higher a single numeric value indicating the percentage
 #' of years that the maximum annual specific conductance for a particular site
 #' should occur during the winter in order to qualify as an episodic winter
 #' salting site. Given as a fraction; defaults to `0.75` (or 75%).
 #' 
 summarize_salt_peaks <- function(ts_peak_data, winter_months = c(12,1,2,3), 
-                                 min_perc_peaks_winter = 0.50, min_perc_diff = 0.10, 
+                                 min_perc_peaks_winter = 0.50,  
                                  min_perc_winter_higher = 0.75) {
   
   # Calculate maximum SpC by site, year, and season. Then determine annual 
@@ -107,8 +103,6 @@ summarize_salt_peaks <- function(ts_peak_data, winter_months = c(12,1,2,3),
     mutate(is_salt_site = 
              # More than `min_perc_peaks_winter` percent of global peaks must occur in winter
              peaks_perc_winterYes > min_perc_peaks_winter & 
-             # The non-winter and winter mean SpC must be more than `min_perc_diff` percent different
-             # sc_perc_diff > min_perc_diff &
              winterPeaks > 6 &
              peakSpc >= 200 + meanSpc &
              # Maximum annual SpC should occur in winter more than `` percent of the years

--- a/7_Disseminate.R
+++ b/7_Disseminate.R
@@ -133,6 +133,28 @@ p7_targets <- list(
                                       p7_site_categories, p1_conus_state_cds), 
              format='file'),
   
+  ##### Plot comparing episodic criteria #####
+  
+  tar_target(p7_episodic_criteria_png, {
+    out_file <- '7_Disseminate/out/episodic_criteria.png'
+    p <- p4_ts_sc_peak_summary %>% 
+      mutate(is_episodic = ifelse(is_episodic, 'Episodic', 'Not episodic')) %>% 
+      ggplot(aes(x = not_winter, y = winter, fill = is_episodic)) +
+      geom_abline(slope = 1, intercept = 0) +
+      geom_point(alpha = 0.5, size=2, shape = 21) +
+      scale_fill_manual(values = c(`Not episodic` = '#005271', Episodic = '#c28e0d'),
+                        name = NULL) +
+      theme_bw() +
+      theme(legend.position = 'bottom',
+            panel.grid = element_blank(),
+            axis.title.x = element_text(vjust = -2),
+            axis.title.y = element_text(vjust = 2)) +
+      xlab('Non-Winter Median Peak SpC') +
+      ylab('Winter Median Peak SpC')
+    ggsave(out_file, p, width = 3.25, height = 3.25, dpi = 500, bg='white')
+    return(out_file)
+  }),
+  
   ##### Save plots of episodic behavior for each site #####
   
   tar_target(p7_episodic_plotlist, create_episodic_plotlist(p3_ts_sc_qualified, p4_episodic_sites)),

--- a/_targets.R
+++ b/_targets.R
@@ -44,10 +44,9 @@ source('4_EpisodicSalinization.R')
 source('5_DefineCharacteristics.R')
 source('6_PredictClass.R')
 source('7_Disseminate.R')
-source('8_Yahara.R')
 
 select <- dplyr::select # The raster pkg keeps overriding this one so make sure this is correct
 
 c(p1_targets, p2_targets, p3_targets,
   p4_targets, p5_targets, p6_targets,
-  p7_targets, p8_targets)
+  p7_targets)


### PR DESCRIPTION
Part of #16. This does a few things:

1. Cleans up the original peak identification fxn to not filter out peaks below the 75th percentile (oops - we missed that before!)
2. Simplifies the criteria for what makes a site episodic by leaning on the idea that top `n` peaks per year and season can be compared. Right now, we compare the overall medians but I think it might be useful to do a simple test of means if we think bigger/smaller values should have more influence. I ran it real quick and there are 99 sites that end up as episodic instead of 90 but I don't have time right now to look at their time series. @hdugan if you want, you could easily try it by replacing `median` with `mean` on line 51 of `4_EpisodicSalinization/src/summarize_sc_peaks.R`.
3. Creates a new figure called `episodic_criteria.png` in the `7_Disseminate/out` folder.